### PR TITLE
더이상 사용되지 않는 graph api 주소를 최신 api 주소로 대체

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -185,7 +185,7 @@ class SmartThingsApi:
     def update(self):
         """Update function for updating api information."""
         try:
-            SMARTTHINGS_API_URL = 'https://graph-ap02-apnortheast2.api.smartthings.com/device/{0}/events'.format(self.deviceId)
+            SMARTTHINGS_API_URL = 'https://api.smartthings.com/v1/devices{0}/events'.format(self.deviceId)
 
             response = requests.get(SMARTTHINGS_API_URL, timeout=10, headers=self.headers)
 

--- a/climate.py
+++ b/climate.py
@@ -185,7 +185,7 @@ class SmartThingsApi:
     def update(self):
         """Update function for updating api information."""
         try:
-            SMARTTHINGS_API_URL = 'https://api.smartthings.com/v1/devices{0}/events'.format(self.deviceId)
+            SMARTTHINGS_API_URL = 'https://api.smartthings.com/v1/devices/{0}/events'.format(self.deviceId)
 
             response = requests.get(SMARTTHINGS_API_URL, timeout=10, headers=self.headers)
 

--- a/sensor.py
+++ b/sensor.py
@@ -68,7 +68,7 @@ class SmartThingsApi:
     def update(self):
         """Update function for updating api information."""
         try:
-            SMARTTHINGS_API_URL = 'https://graph-ap02-apnortheast2.api.smartthings.com/device/{0}/events'.format(self.deviceId)
+            SMARTTHINGS_API_URL = 'https://api.smartthings.com/v1/devices/{0}/events'.format(self.deviceId)
 
             response = requests.get(SMARTTHINGS_API_URL, timeout=10, headers=self.headers)
 


### PR DESCRIPTION
climate.py에 보일러의 전체 상태를 불러오는 부분의 API 주소는 더 이상 사용하지 않는 주소입니다.

```python
...
def update(self):
    """Update function for updating api information."""
    try:
        SMARTTHINGS_API_URL = 'https://graph-ap02-apnortheast2.api.smartthings.com/device/{0}/events'.format(self.deviceId)

    response = requests.get(SMARTTHINGS_API_URL, timeout=10, headers=self.headers)
...
``` 

그래서 위의 부분을 아래와 같이 수정했습니다.

```python
...
def update(self):
    """Update function for updating api information."""
    try:
        SMARTTHINGS_API_URL = 'https://api.smartthings.com/v1/devices/{0}/events'.format(self.deviceId)

    response = requests.get(SMARTTHINGS_API_URL, timeout=10, headers=self.headers)
...
``` 